### PR TITLE
Support external hub url

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,15 @@ Available actions:
 
 # Example
 
-How to create an flist, upload playloads and upload flist into playground hub:
+How to create an flist, upload playloads and upload flist into playground hub. By default, `zflist`
+will use production hub (`hub.grid.tf`) but you can override that by setting `ZFLIST_HUB` environment
+variable, like below.
+
 ```
 export ZFLIST_MNT=/tmp/zflistmnt
+export ZFLIST_HUB="https://playground.hub.grid.tf"
 export ZFLIST_BACKEND='{"host": "playground.hub.grid.tf", "port": 9910}'
-export ZFLIST_HUB_TOKEN=eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVC....
+export ZFLIST_HUB_TOKEN=kiUTd9jRjgt7QB6lRh2bcpNiC2UqvTLI
 
 zflist init
 zflist putdir /tmp/20191021_150741 /

--- a/zflist/actions.c
+++ b/zflist/actions.c
@@ -762,6 +762,8 @@ int zf_hub(zf_callback_t *cb) {
     // checking if a special user is specified
     cb->settings->user = getenv("ZFLIST_HUB_USER");
 
+    debug("[+] hub: baseurl: %s\n", cb->settings->baseurl);
+
     // skipping first argument
     cb->argc -= 1;
     cb->argv += 1;

--- a/zflist/zflist.c
+++ b/zflist/zflist.c
@@ -135,6 +135,9 @@ int main(int argc, char *argv[]) {
         nargv = argv + 2;
     }
 
+    if(!(settings.baseurl = getenv("ZFLIST_HUB")))
+        settings.baseurl = ZFLIST_HUB_BASEURL;
+
     if(nargc < 1)
         usage(argv[0]);
 

--- a/zflist/zflist.h
+++ b/zflist/zflist.h
@@ -3,6 +3,8 @@
 
     #define ZFLIST_VERSION  "1.0"
 
+    #define ZFLIST_HUB_BASEURL   "https://hub.grid.tf"
+
     #ifdef FLIST_DEBUG
         #define debug(...) { printf(__VA_ARGS__); }
     #else
@@ -19,6 +21,7 @@
         char *bpass;         // backend password
         char *token;         // 0-hub jwt token
         char *user;          // 0-hub active user
+        char *baseurl;       // 0-hub base url
 
     } zfe_settings_t;
 


### PR DESCRIPTION
Previously, hub URL was hardcoded and could not be changed except by changing code. This pull request add support to define hub baseurl via environment variable.
```sh
ZFLIST_HUB="https://playground.hub.grid.tf"
```