### PR TITLE
Support uid/gid and stay retro-compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: all
 
 release:
-	cd libflist && $(MAKE) $@
+	cd libflist && $(MAKE)
 	cd zflist && $(MAKE) embedded
 	cp zflist/zflist zflist-embedded
 	strip -s zflist-embedded

--- a/format/README.md
+++ b/format/README.md
@@ -1,0 +1,8 @@
+# Generate C files from model
+
+Require `c-capnproto` and `capnproto`
+
+```
+capnp compile -oc flist.capnp
+cp flist.capnp.* ../libflist/
+```

--- a/format/flist.capnp
+++ b/format/flist.capnp
@@ -1,0 +1,98 @@
+@0xae9223e76351538a;
+
+struct FileBlock {
+    hash @0: Data;  # File hash stored as key on the backend
+    key  @1: Data;  # Encryption key
+}
+
+struct File {
+    # blocksize in bytes = blocksize * 4 KB, blocksize is same for all parts of file
+    # max blocksize = 128 MB
+    blockSize   @0: UInt16;
+    blocks      @1: List(FileBlock);    # list of the hashes of the blocks
+}
+
+struct Link {
+    target @0: Text;  # Path to target
+}
+
+struct Special {
+    type @0: Type;
+
+    # 0 => socket       (S_IFSOCK)
+    # 1 => block device (S_IFBLK)
+    # 2 => char. device (S_IFCHR)
+    # 3 => fifo pipe    (S_IFIFO)
+    enum Type {
+        socket   @0;
+        block    @1;
+        chardev  @2;
+        fifopipe @3;
+        unknown  @4;
+    }
+
+    data @1: Data;     # data relevant for type of item
+}
+
+struct SubDir {
+    key  @0: Text;    # Key ID of the subdirectory
+}
+
+struct Inode {
+    name    @0: Text;
+    size    @1: UInt64;           # in bytes
+
+    attributes: union {
+        dir     @2: SubDir;
+        file    @3: File;
+        link    @4: Link;
+        special @5: Special;
+    }
+
+    aclkey           @6: Text;    # is pointer to ACL # FIXME: need to be int
+    modificationTime @7: UInt32;
+    creationTime     @8: UInt32;
+}
+
+struct Dir {
+    name     @0: Text;            # name of dir
+
+    location @1: Text;            # location in filesystem = namespace
+    contents @2: List(Inode);     # list of the contents (files, links, specials)
+    parent   @3: Text;            # directory key of parent
+
+    # directory's metadata
+
+    size             @4: UInt64;  # in bytes
+    aclkey           @5: Text;    # is pointer to ACL # FIXME: need to be int
+    modificationTime @6: UInt32;
+    creationTime     @7: UInt32;
+}
+
+struct UserGroup {
+    name   @0: Text;
+    iyoId  @1: Text;    # itsyou.online id
+    iyoInt @2: UInt64;  # itsyouonline unique id per user or group, is globally unique
+}
+
+
+struct ACI {
+    # for backwards compatibility with posix
+    uname @0: Text;
+    gname @1: Text;
+    mode  @2: UInt16;
+
+    rights @3 :List(Right);
+    struct Right {
+        # text e.g. rwdl- (admin read write delete list -), freely to be chosen
+        # admin means all rights (e.g. on / = namespace or filesystem level all rights for everything)
+        # - means remove all previous ones (is to stop recursion), if usergroupid=0 then is for all users & all groups
+        right       @0: Text;
+        usergroupid @1: UInt16;
+    }
+
+    id @4: UInt32;
+
+    uid @5 :Int64 = -1;
+    gid @6 :Int64 = -1;
+}

--- a/libflist/flist.capnp.c
+++ b/libflist/flist.capnp.c
@@ -1,5 +1,13 @@
 #include "flist.capnp.h"
 /* AUTO GENERATED - DO NOT EDIT */
+#ifdef __GNUC__
+# define capnp_unused __attribute__((unused))
+# define capnp_use(x) (void) x;
+#else
+# define capnp_unused
+# define capnp_use(x)
+#endif
+
 static const capn_text capn_val0 = {0,"",0};
 
 FileBlock_ptr new_FileBlock(struct capn_segment *s) {
@@ -12,13 +20,15 @@ FileBlock_list new_FileBlock_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 0, 2);
 	return p;
 }
-void read_FileBlock(struct FileBlock *s, FileBlock_ptr p) {
+void read_FileBlock(struct FileBlock *s capnp_unused, FileBlock_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->hash = capn_get_data(p.p, 0);
 	s->key = capn_get_data(p.p, 1);
 }
-void write_FileBlock(const struct FileBlock *s, FileBlock_ptr p) {
+void write_FileBlock(const struct FileBlock *s capnp_unused, FileBlock_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_setp(p.p, 0, s->hash.p);
 	capn_setp(p.p, 1, s->key.p);
 }
@@ -43,13 +53,15 @@ File_list new_File_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 8, 1);
 	return p;
 }
-void read_File(struct File *s, File_ptr p) {
+void read_File(struct File *s capnp_unused, File_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->blockSize = capn_read16(p.p, 0);
 	s->blocks.p = capn_getp(p.p, 0, 0);
 }
-void write_File(const struct File *s, File_ptr p) {
+void write_File(const struct File *s capnp_unused, File_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_write16(p.p, 0, s->blockSize);
 	capn_setp(p.p, 0, s->blocks.p);
 }
@@ -74,12 +86,14 @@ Link_list new_Link_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 0, 1);
 	return p;
 }
-void read_Link(struct Link *s, Link_ptr p) {
+void read_Link(struct Link *s capnp_unused, Link_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->target = capn_get_text(p.p, 0, capn_val0);
 }
-void write_Link(const struct Link *s, Link_ptr p) {
+void write_Link(const struct Link *s capnp_unused, Link_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_set_text(p.p, 0, s->target);
 }
 void get_Link(struct Link *s, Link_list l, int i) {
@@ -103,13 +117,15 @@ Special_list new_Special_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 8, 1);
 	return p;
 }
-void read_Special(struct Special *s, Special_ptr p) {
+void read_Special(struct Special *s capnp_unused, Special_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->type = (enum Special_Type)(int) capn_read16(p.p, 0);
 	s->data = capn_get_data(p.p, 0);
 }
-void write_Special(const struct Special *s, Special_ptr p) {
+void write_Special(const struct Special *s capnp_unused, Special_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_write16(p.p, 0, (uint16_t) (s->type));
 	capn_setp(p.p, 0, s->data.p);
 }
@@ -134,12 +150,14 @@ SubDir_list new_SubDir_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 0, 1);
 	return p;
 }
-void read_SubDir(struct SubDir *s, SubDir_ptr p) {
+void read_SubDir(struct SubDir *s capnp_unused, SubDir_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->key = capn_get_text(p.p, 0, capn_val0);
 }
-void write_SubDir(const struct SubDir *s, SubDir_ptr p) {
+void write_SubDir(const struct SubDir *s capnp_unused, SubDir_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_set_text(p.p, 0, s->key);
 }
 void get_SubDir(struct SubDir *s, SubDir_list l, int i) {
@@ -163,8 +181,9 @@ Inode_list new_Inode_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 24, 3);
 	return p;
 }
-void read_Inode(struct Inode *s, Inode_ptr p) {
+void read_Inode(struct Inode *s capnp_unused, Inode_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->name = capn_get_text(p.p, 0, capn_val0);
 	s->size = capn_read64(p.p, 0);
 	s->attributes_which = (enum Inode_attributes_which)(int) capn_read16(p.p, 8);
@@ -182,8 +201,9 @@ void read_Inode(struct Inode *s, Inode_ptr p) {
 	s->modificationTime = capn_read32(p.p, 12);
 	s->creationTime = capn_read32(p.p, 16);
 }
-void write_Inode(const struct Inode *s, Inode_ptr p) {
+void write_Inode(const struct Inode *s capnp_unused, Inode_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_set_text(p.p, 0, s->name);
 	capn_write64(p.p, 0, s->size);
 	capn_write16(p.p, 8, s->attributes_which);
@@ -222,8 +242,9 @@ Dir_list new_Dir_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 16, 5);
 	return p;
 }
-void read_Dir(struct Dir *s, Dir_ptr p) {
+void read_Dir(struct Dir *s capnp_unused, Dir_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->name = capn_get_text(p.p, 0, capn_val0);
 	s->location = capn_get_text(p.p, 1, capn_val0);
 	s->contents.p = capn_getp(p.p, 2, 0);
@@ -233,8 +254,9 @@ void read_Dir(struct Dir *s, Dir_ptr p) {
 	s->modificationTime = capn_read32(p.p, 8);
 	s->creationTime = capn_read32(p.p, 12);
 }
-void write_Dir(const struct Dir *s, Dir_ptr p) {
+void write_Dir(const struct Dir *s capnp_unused, Dir_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_set_text(p.p, 0, s->name);
 	capn_set_text(p.p, 1, s->location);
 	capn_setp(p.p, 2, s->contents.p);
@@ -265,14 +287,16 @@ UserGroup_list new_UserGroup_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 8, 2);
 	return p;
 }
-void read_UserGroup(struct UserGroup *s, UserGroup_ptr p) {
+void read_UserGroup(struct UserGroup *s capnp_unused, UserGroup_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->name = capn_get_text(p.p, 0, capn_val0);
 	s->iyoId = capn_get_text(p.p, 1, capn_val0);
 	s->iyoInt = capn_read64(p.p, 0);
 }
-void write_UserGroup(const struct UserGroup *s, UserGroup_ptr p) {
+void write_UserGroup(const struct UserGroup *s capnp_unused, UserGroup_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_set_text(p.p, 0, s->name);
 	capn_set_text(p.p, 1, s->iyoId);
 	capn_write64(p.p, 0, s->iyoInt);
@@ -298,16 +322,18 @@ ACI_list new_ACI_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 8, 3);
 	return p;
 }
-void read_ACI(struct ACI *s, ACI_ptr p) {
+void read_ACI(struct ACI *s capnp_unused, ACI_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->uname = capn_get_text(p.p, 0, capn_val0);
 	s->gname = capn_get_text(p.p, 1, capn_val0);
 	s->mode = capn_read16(p.p, 0);
 	s->rights.p = capn_getp(p.p, 2, 0);
 	s->id = capn_read32(p.p, 4);
 }
-void write_ACI(const struct ACI *s, ACI_ptr p) {
+void write_ACI(const struct ACI *s capnp_unused, ACI_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_set_text(p.p, 0, s->uname);
 	capn_set_text(p.p, 1, s->gname);
 	capn_write16(p.p, 0, s->mode);
@@ -335,13 +361,15 @@ ACI_Right_list new_ACI_Right_list(struct capn_segment *s, int len) {
 	p.p = capn_new_list(s, len, 8, 1);
 	return p;
 }
-void read_ACI_Right(struct ACI_Right *s, ACI_Right_ptr p) {
+void read_ACI_Right(struct ACI_Right *s capnp_unused, ACI_Right_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	s->right = capn_get_text(p.p, 0, capn_val0);
 	s->usergroupid = capn_read16(p.p, 0);
 }
-void write_ACI_Right(const struct ACI_Right *s, ACI_Right_ptr p) {
+void write_ACI_Right(const struct ACI_Right *s capnp_unused, ACI_Right_ptr p) {
 	capn_resolve(&p.p);
+	capnp_use(s);
 	capn_set_text(p.p, 0, s->right);
 	capn_write16(p.p, 0, s->usergroupid);
 }

--- a/libflist/flist.capnp.c
+++ b/libflist/flist.capnp.c
@@ -314,12 +314,12 @@ void set_UserGroup(const struct UserGroup *s, UserGroup_list l, int i) {
 
 ACI_ptr new_ACI(struct capn_segment *s) {
 	ACI_ptr p;
-	p.p = capn_new_struct(s, 8, 3);
+	p.p = capn_new_struct(s, 24, 3);
 	return p;
 }
 ACI_list new_ACI_list(struct capn_segment *s, int len) {
 	ACI_list p;
-	p.p = capn_new_list(s, len, 8, 3);
+	p.p = capn_new_list(s, len, 24, 3);
 	return p;
 }
 void read_ACI(struct ACI *s capnp_unused, ACI_ptr p) {
@@ -330,6 +330,8 @@ void read_ACI(struct ACI *s capnp_unused, ACI_ptr p) {
 	s->mode = capn_read16(p.p, 0);
 	s->rights.p = capn_getp(p.p, 2, 0);
 	s->id = capn_read32(p.p, 4);
+	s->uid = (int64_t) ((int64_t)(capn_read64(p.p, 8)) ^ ((int64_t)((uint64_t) 0xffffffffu << 32) ^ 0xffffffffu));
+	s->gid = (int64_t) ((int64_t)(capn_read64(p.p, 16)) ^ ((int64_t)((uint64_t) 0xffffffffu << 32) ^ 0xffffffffu));
 }
 void write_ACI(const struct ACI *s capnp_unused, ACI_ptr p) {
 	capn_resolve(&p.p);
@@ -339,6 +341,8 @@ void write_ACI(const struct ACI *s capnp_unused, ACI_ptr p) {
 	capn_write16(p.p, 0, s->mode);
 	capn_setp(p.p, 2, s->rights.p);
 	capn_write32(p.p, 4, s->id);
+	capn_write64(p.p, 8, (uint64_t) (s->uid ^ ((int64_t)((uint64_t) 0xffffffffu << 32) ^ 0xffffffffu)));
+	capn_write64(p.p, 16, (uint64_t) (s->gid ^ ((int64_t)((uint64_t) 0xffffffffu << 32) ^ 0xffffffffu)));
 }
 void get_ACI(struct ACI *s, ACI_list l, int i) {
 	ACI_ptr p;

--- a/libflist/flist.capnp.h
+++ b/libflist/flist.capnp.h
@@ -176,13 +176,15 @@ struct ACI {
 	uint16_t mode;
 	ACI_Right_list rights;
 	uint32_t id;
+	int64_t uid;
+	int64_t gid;
 };
 
-static const size_t ACI_word_count = 1;
+static const size_t ACI_word_count = 3;
 
 static const size_t ACI_pointer_count = 3;
 
-static const size_t ACI_struct_bytes_count = 32;
+static const size_t ACI_struct_bytes_count = 48;
 
 struct ACI_Right {
 	capn_text right;

--- a/libflist/flist.capnp.h
+++ b/libflist/flist.capnp.h
@@ -1,11 +1,18 @@
 #ifndef CAPN_AE9223E76351538A
 #define CAPN_AE9223E76351538A
 /* AUTO GENERATED - DO NOT EDIT */
-#include <unistd.h>
 #include <capnp_c.h>
 
 #if CAPN_VERSION != 1
 #error "version mismatch between capnp_c.h and generated code"
+#endif
+
+#ifndef capnp_nowarn
+# ifdef __GNUC__
+#  define capnp_nowarn __extension__
+# else
+#  define capnp_nowarn
+# endif
 #endif
 
 
@@ -117,7 +124,7 @@ struct Inode {
 	capn_text name;
 	uint64_t size;
 	enum Inode_attributes_which attributes_which;
-	union {
+	capnp_nowarn union {
 		SubDir_ptr dir;
 		File_ptr file;
 		Link_ptr link;

--- a/libflist/flist_acl.h
+++ b/libflist/flist_acl.h
@@ -3,7 +3,7 @@
 
     char *flist_acl_key(acl_t *acl);
     acl_t *flist_acl_commit(acl_t *acl);
-    acl_t *flist_acl_new(char *uname, char *gname, int mode);
+    acl_t *flist_acl_new(char *uname, char *gname, int mode, int64_t uid, int64_t gid);
     acl_t *flist_acl_duplicate(acl_t *source);
     acl_t *flist_acl_from_stat(const struct stat *sb);
     void flist_acl_free(acl_t *acl);

--- a/libflist/flist_dirnode.c
+++ b/libflist/flist_dirnode.c
@@ -40,7 +40,7 @@ dirnode_t *flist_dirnode_create(char *fullpath, char *name) {
         directory->fullpath[lf - 1] = '\0';
 
     directory->hashkey = flist_path_key(directory->fullpath);
-    directory->acl = flist_acl_new("root", "root", 0755);
+    directory->acl = flist_acl_new("root", "root", 0755, 0, 0);
 
     return directory;
 }

--- a/libflist/flist_dumps.c
+++ b/libflist/flist_dumps.c
@@ -28,6 +28,7 @@ void libflist_inode_dumps(inode_t *inode, dirnode_t *rootdir) {
 
     debug("[+] inode: aclkey: %s\n", inode->acl->key);
     debug("[+] inode:   user: %s, group: %s\n", inode->acl->uname, inode->acl->gname);
+    debug("[+] inode:   uid: %ld, gid: %ld\n", inode->acl->uid, inode->acl->gid);
     debug("[+] inode:   mode: %o\n", inode->acl->mode);
 
     if(inode->type == INODE_LINK)

--- a/libflist/flist_inode.c
+++ b/libflist/flist_inode.c
@@ -251,7 +251,7 @@ inode_t *flist_inode_mkdir(char *name, dirnode_t *parent) {
     inode->modification = time(NULL);
     inode->type = INODE_DIRECTORY;
     inode->subdirkey = libflist_path_key(vpath);
-    inode->acl = flist_acl_new("root", "root", 0755);
+    inode->acl = flist_acl_new("root", "root", 0755, 0, 0);
 
     return inode;
 }

--- a/libflist/flist_serial.c
+++ b/libflist/flist_serial.c
@@ -195,6 +195,8 @@ acl_t *flist_serial_get_acl(flist_db_t *database, const char *aclkey) {
     acl->gname = strdup(aci.gname.str);
     acl->mode = aci.mode;
     acl->key = strdup(aclkey);
+    acl->uid = aci.uid;
+    acl->gid = aci.gid;
 
     capn_free(&permsctx);
     database->clean(rawdata);
@@ -215,6 +217,8 @@ void flist_serial_commit_acl(flist_db_t *database, acl_t *acl) {
         .gname = chars_to_text(acl->gname),
         .mode = acl->mode,
         .id = 0,
+        .uid = acl->uid,
+        .gid = acl->gid,
     };
 
     // prepare a writer

--- a/libflist/libflist.h
+++ b/libflist/libflist.h
@@ -18,6 +18,8 @@
         char *gname;     // group name (group id if not found)
         uint16_t mode;   // integer file mode
         char *key;       // hash of the payload (dedupe in db)
+        int64_t uid;     // hardcoded user id from stat
+        int64_t gid;     // hardcoded group id from stat
 
     } acl_t;
 
@@ -287,7 +289,7 @@
     //
     // flist_acl.c
     //
-    acl_t *libflist_acl_new(char *uname, char *gname, int mode);
+    acl_t *libflist_acl_new(char *uname, char *gname, int mode, int64_t uid, int64_t gid);
     char *libflist_acl_key(acl_t *acl);
     acl_t *libflist_acl_duplicate(acl_t *source);
     acl_t *libflist_acl_commit(acl_t *acl);

--- a/zflist/actions.c
+++ b/zflist/actions.c
@@ -351,7 +351,9 @@ static int zf_ls_json(zf_callback_t *cb, dirnode_t *dirnode) {
         json_object_set(entry, "type", json_string(zf_inode_typename(inode->type, inode->stype)));
         json_object_set(entry, "size", json_integer(inode->size));
         json_object_set(entry, "user", json_string(inode->acl->uname));
+        json_object_set(entry, "uid", json_integer(inode->acl->uid));
         json_object_set(entry, "group", json_string(inode->acl->gname));
+        json_object_set(entry, "gid", json_integer(inode->acl->gid));
 
         json_array_append(list, entry);
     }

--- a/zflist/tools.c
+++ b/zflist/tools.c
@@ -147,7 +147,9 @@ int zf_stat_inode_json(zf_callback_t *cb, inode_t *inode) {
     json_object_set_new(response, "size", json_integer(inode->size));
     json_object_set_new(response, "mode", json_integer(inode->acl->mode));
     json_object_set_new(response, "user", json_string(inode->acl->uname));
+    json_object_set_new(response, "uid", json_integer(inode->acl->uid));
     json_object_set_new(response, "group", json_string(inode->acl->gname));
+    json_object_set_new(response, "gid", json_integer(inode->acl->gid));
     json_object_set_new(response, "created", json_integer(inode->creation));
     json_object_set_new(response, "modified", json_integer(inode->modification));
 
@@ -183,7 +185,8 @@ static int zf_stat_inode_text(inode_t *inode) {
     printf("Access: (%o/%c", inode->acl->mode, zf_ls_inode_type(inode));
     zf_ls_inode_perm(inode);
 
-    printf(")  UID: %s, GID: %s\n", inode->acl->uname, inode->acl->gname);
+    acl_t *acl = inode->acl;
+    printf(")  UID: %ld (%s), GID: %ld (%s)\n", acl->uid, acl->uname, acl->gid, acl->gname);
 
     printf("Access: %lu\n", inode->modification);
     printf("Create: %lu\n", inode->creation);

--- a/zflist/zflist.c
+++ b/zflist/zflist.c
@@ -33,7 +33,7 @@ zf_cmds_t zf_commands[] = {
     {.name = "merge",    .db = 1, .callback = zf_merge,    .help = "merge another flist into the current one"},
     {.name = "check",    .db = 1, .callback = zf_check,    .help = "check archive integrity (chunks valid in the backed)"},
     {.name = "debug",    .db = 1, .callback = zf_debug,    .help = "provide and apply some debug features"},
-    {.name = "prefetch", .db = 1, .callback = zf_prefetch, .help = "read directory contents to fill flist cache"},
+    {.name = "prefetch", .db = 0, .callback = zf_prefetch, .help = "read directory contents to fill flist cache"},
     {.name = "hub",      .db = 0, .callback = zf_hub,      .help = "0-hub command line tools"},
     {.name = "commit",   .db = 0, .callback = zf_commit,   .help = "commit changes to a new flist"},
     {.name = "close",    .db = 0, .callback = zf_close,    .help = "close mountpoint and discard files"},


### PR DESCRIPTION
Improve flist format, including UID and GID on ACL.

When creating an flist, the uid/gid of directories and files are copied from host, directly, in addition to username/groupname.
This ID can be used to foward real userid/groupid from host system and not a resolved name if not desired.

This include also the capnp model used, copied from `0-fs`.